### PR TITLE
switch to prosody 0.12 new default network backend 'epoll'

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,8 @@ prosody_authentication: internal_hashed
 prosody_dhparam_length: 2048
 prosody_welcome_msg: "Hello $username, welcome to the $host IM server!"
 
+prosody_network_backend: '"epoll"'
+
 # Set either a string, or a list of strings. If a list is given, the external
 # module "motd_sequential" will be activated and used automatically.
 # motd_sequential is a variant of mod_motd, that lets you specify a sequence
@@ -107,7 +109,6 @@ prosody_packages:
   - mercurial
   - lua-sec
   - lua-bitop
-  - lua-event
   - lua-unbound
   - lua5.2
 

--- a/molecule/default/tests/test_default.yml
+++ b/molecule/default/tests/test_default.yml
@@ -10,8 +10,6 @@ service:
     running: true
 
 command:
-  prosodyctl check config | grep -v libevent:
-    exit-status: 0
 
   prosodyctl about:
     exit-status: 0

--- a/templates/prosody.cfg.lua.j2
+++ b/templates/prosody.cfg.lua.j2
@@ -26,11 +26,9 @@ admins = {
 {% endfor %}
 }
 
--- Enable use of libevent for better performance under high load
--- For more information see: https://prosody.im/doc/libevent
-{% if prosody_libevent|default(True) %}
-network_backend = "event"
-{% endif %}
+-- Define prosody network backend
+-- For more information see: https://prosody.im/doc/network_backend
+network_backend = {{ prosody_network_backend }}
 
 -- Prosody will always look in its source directory for modules, but
 -- this option allows you to specify additional locations where Prosody

--- a/templates/test_prosody.yml.j2
+++ b/templates/test_prosody.yml.j2
@@ -10,8 +10,6 @@ service:
     running: true
 
 command:
-  prosodyctl check config | grep -v libevent:
-    exit-status: 0
   prosodyctl check certs:
     exit-status: 0
 


### PR DESCRIPTION
see: https://prosody.im/doc/network_backend#epoll

also needed as a preparation to switch to lua5.4 
(recommended lua version for prosody 0.12), will be
next PR
